### PR TITLE
docs: evidence-based narrative for profile sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ func main() {
 
 func GetBio() Bio {
     return Bio{
-        "- 🌱 currently learning":     "Rust, Blockchain, CyberSecurity",
-        "- 👯 open to collaborate on": "new solutions and open-source projects",
-        "- 💬 ask me about":           "DevOps, Kubernetes, CI/CD, IaC, Cloud",
+        "- 🔧 what I build":        "CLIs, pipelines and IaC that remove humans from deploys",
+        "- 📜 proof":               "14 verified certifications (AWS, Kubernetes, Terraform)",
+        "- 🌱 currently learning":  "Rust, Blockchain, CyberSecurity",
+        "- 💬 ask me about":        "DevOps, Kubernetes, CI/CD, IaC, Cloud",
     }
 }
 ```
@@ -69,16 +70,18 @@ func GetBio() Bio {
 
 | repo | description | stars |
 | --- | --- | --- |
-| [docker-crypto-miner](https://github.com/lpsm-dev/docker-crypto-miner) | user-friendly image for mining cryptocurrencies with your CPU | ![stars](https://img.shields.io/github/stars/lpsm-dev/docker-crypto-miner?style=flat-square&labelColor=black&color=white&label=%E2%98%85) |
-| [loli](https://github.com/lpsm-dev/loli) | pretty CLI to find animes by passing images | ![stars](https://img.shields.io/github/stars/lpsm-dev/loli?style=flat-square&labelColor=black&color=white&label=%E2%98%85) |
-| [azure-pipelines](https://github.com/lpsm-dev/azure-pipelines) | Azure DevOps pipeline: build, scan, test and deploy steps | ![stars](https://img.shields.io/github/stars/lpsm-dev/azure-pipelines?style=flat-square&labelColor=black&color=white&label=%E2%98%85) |
-| [gitlabrc](https://github.com/lpsm-dev/gitlabrc) | recursively clone all projects of a GitLab namespace | ![stars](https://img.shields.io/github/stars/lpsm-dev/gitlabrc?style=flat-square&labelColor=black&color=white&label=%E2%98%85) |
+| [docker-crypto-miner](https://github.com/lpsm-dev/docker-crypto-miner) | mining setups are a dependency mess - this image makes it one `docker run` | ![stars](https://img.shields.io/github/stars/lpsm-dev/docker-crypto-miner?style=flat-square&labelColor=black&color=white&label=%E2%98%85) |
+| [loli](https://github.com/lpsm-dev/loli) | you have the screenshot but not the anime name - this CLI finds it | ![stars](https://img.shields.io/github/stars/lpsm-dev/loli?style=flat-square&labelColor=black&color=white&label=%E2%98%85) |
+| [azure-pipelines](https://github.com/lpsm-dev/azure-pipelines) | reusable build, scan and deploy steps so every project doesn't reinvent them | ![stars](https://img.shields.io/github/stars/lpsm-dev/azure-pipelines?style=flat-square&labelColor=black&color=white&label=%E2%98%85) |
+| [gitlabrc](https://github.com/lpsm-dev/gitlabrc) | cloning an entire GitLab group by hand doesn't scale - one command does it | ![stars](https://img.shields.io/github/stars/lpsm-dev/gitlabrc?style=flat-square&labelColor=black&color=white&label=%E2%98%85) |
 
 [all repositories →](https://github.com/lpsm-dev?tab=repositories)
 
 ## `$ contributions`
 
-- [google/go-github#2250](https://github.com/google/go-github/pull/2250) - add pagination options to list all package versions
+My registry-pruning tool [drprune](https://github.com/lpsm-dev/drprune) needed to list **all** versions of a container image - the GitHub SDK only fetched the first page. So I fixed it upstream:
+
+- [google/go-github#2250](https://github.com/google/go-github/pull/2250) - add pagination options to list all package versions (merged)
 
 ## `$ certifications`
 
@@ -143,4 +146,4 @@ func GetBio() Bio {
 
 ---
 
-<samp>$ echo "I love new connections - if you want to say hi, I'll be happy to meet you!"</samp>
+<samp>$ echo "want to collaborate? open an issue - I answer all of them"</samp>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lpsm-dev
 
-<samp>DevOps · Cloud · Automation · Open Source</samp>
+<samp>DevOps · Cloud · AI Agents · Automation · Open Source</samp>
 
 [![followers](https://img.shields.io/github/followers/lpsm-dev?style=flat-square&labelColor=black&color=white&label=follow)](https://github.com/lpsm-dev)
 [![stars](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github-star-counter.workers.dev%2Fuser%2Flpsm-dev&query=%24.stars&style=flat-square&labelColor=black&color=white&label=stars)](https://github.com/lpsm-dev?tab=repositories&sort=stargazers)
@@ -29,9 +29,10 @@ func main() {
 func GetBio() Bio {
     return Bio{
         "- 🔧 what I build":        "CLIs, pipelines and IaC that remove humans from deploys",
+        "- 🤖 lately shipping":     "AI agents, MCP tooling and multi-tenant cloud platforms",
         "- 📜 proof":               "14 verified certifications (AWS, Kubernetes, Terraform)",
         "- 🌱 currently learning":  "Rust, Blockchain, CyberSecurity",
-        "- 💬 ask me about":        "DevOps, Kubernetes, CI/CD, IaC, Cloud",
+        "- 💬 ask me about":        "DevOps, Kubernetes, CI/CD, IaC, FinOps, AI agents",
     }
 }
 ```
@@ -64,6 +65,12 @@ func GetBio() Bio {
   <img alt="Argo" src="https://img.shields.io/badge/Argo-black?style=for-the-badge&logo=argo&logoColor=white">
   <img alt="Prometheus" src="https://img.shields.io/badge/Prometheus-black?style=for-the-badge&logo=prometheus&logoColor=white">
   <img alt="Grafana" src="https://img.shields.io/badge/Grafana-black?style=for-the-badge&logo=grafana&logoColor=white">
+  <img alt="Datadog" src="https://img.shields.io/badge/Datadog-black?style=for-the-badge&logo=datadog&logoColor=white">
+  <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-black?style=for-the-badge&logo=typescript&logoColor=white">
+  <img alt="React" src="https://img.shields.io/badge/React-black?style=for-the-badge&logo=react&logoColor=white">
+  <img alt="Claude" src="https://img.shields.io/badge/Claude-black?style=for-the-badge&logo=anthropic&logoColor=white">
+  <img alt="MCP" src="https://img.shields.io/badge/MCP-black?style=for-the-badge&logo=modelcontextprotocol&logoColor=white">
+  <img alt="Amazon Bedrock" src="https://img.shields.io/badge/Amazon%20Bedrock-black?style=for-the-badge">
 </p>
 
 ## `$ pinned`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ $ npx lpsm-dev   # interactive resume card in your terminal
 
 [ask a question](https://github.com/lpsm-dev/lpsm-dev/issues/new) · [browse answered questions](https://github.com/lpsm-dev/lpsm-dev/issues?q=is%3Aissue+is%3Aclosed)
 
+## `$ cat about.txt`
+
+<samp>
+Hi, I'm Lucca - a Brazil-based engineer who turns manual operations into code.
+My day-to-day is the path from commit to production: Kubernetes, Terraform and
+CI/CD pipelines on AWS. Lately I've been teaching AI agents to operate cloud
+infrastructure with me - MCP servers, Bedrock and multi-tenant platforms.
+14 certifications later, the lessons keep shipping as open-source tools.
+</samp>
+
 ## `$ whoami`
 
 ```go


### PR DESCRIPTION
## Summary

Storytelling pass over the README for a technical audience — evidence over adjectives:

- **`$ whoami`**: bio entries now state what I build ("CLIs, pipelines and IaC that remove humans from deploys") and the verifiable proof (14 certifications) instead of generic categories
- **`$ pinned`**: problem-first descriptions — each line names the pain the tool removes
- **`$ contributions`**: the bare bullet becomes the real story: drprune needed full pagination of package versions, the SDK didn't support it, so it was fixed upstream in google/go-github#2250 (merged)
- **Footer**: concrete call to action ("open an issue — I answer all of them")

No invented metrics: every number in the narrative is verifiable on the page itself.

Render: https://github.com/lpsm-dev/lpsm-dev/blob/docs/readme-narrative/README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the profile tagline to highlight AI agents.
  * Expanded the biography with cloud infrastructure, automation, and AI agent expertise.
  * Refreshed “whoami” details, including current learning topics and areas of discussion.
  * Added technology badges for tools such as Datadog, TypeScript, React, Claude, MCP, and Amazon Bedrock.
  * Revised repository descriptions, contribution context, and the collaboration call to action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->