### PR TITLE
docs: add interests section to profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ My registry-pruning tool [drprune](https://github.com/lpsm-dev/drprune) needed t
 
 </details>
 
+## `$ interests`
+
+<samp>Adventure sports · Anime · Camping · Music · Craft beer · Travel</samp>
+
 ## `$ stats`
 
 <details>


### PR DESCRIPTION
Adiciona um bloco `$ interests` ao README do profile, espelhando os interesses do card `npx lpsm-dev`, pra manter profile / CLI / CV conectados.

```
## `$ interests`

Adventure sports · Anime · Camping · Music · Craft beer · Travel
```

Estilo terminal-minimalista consistente com as outras seções (`<samp>` + separador `·`). Posicionado entre `$ certifications` e `$ stats`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an interests section to the README featuring adventure sports, anime, camping, music, craft beer, and travel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->