### PR TITLE
feat: generate README sections and CLI data from the source of truth

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -26,3 +26,15 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITLEAKS_ENABLE_COMMENTS: true
       continue-on-error: false
+  render:
+    name: Render check
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Check out code from GitHub
+      uses: actions/checkout@v7
+    - name: Setup node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+    - name: Verify surfaces match the source of truth
+      run: node scripts/render.mjs --check

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ func GetBio() Bio {
 
 ## `$ stack`
 
+<!-- gen:stack:start -->
 <p>
   <img alt="Linux" src="https://img.shields.io/badge/-Linux-black?style=for-the-badge&logo=linux&logoColor=white">
   <img alt="Windows" src="https://img.shields.io/badge/-Windows-black?&style=for-the-badge&logo=windows&logoColor=white">
@@ -82,9 +83,11 @@ func GetBio() Bio {
   <img alt="MCP" src="https://img.shields.io/badge/MCP-black?style=for-the-badge&logo=modelcontextprotocol&logoColor=white">
   <img alt="Amazon Bedrock" src="https://img.shields.io/badge/Amazon%20Bedrock-black?style=for-the-badge">
 </p>
+<!-- gen:stack:end -->
 
 ## `$ pinned`
 
+<!-- gen:pinned:start -->
 | repo | description | stars |
 | --- | --- | --- |
 | [docker-crypto-miner](https://github.com/lpsm-dev/docker-crypto-miner) | mining setups are a dependency mess - this image makes it one `docker run` | ![stars](https://img.shields.io/github/stars/lpsm-dev/docker-crypto-miner?style=flat-square&labelColor=black&color=white&label=%E2%98%85) |
@@ -93,6 +96,7 @@ func GetBio() Bio {
 | [gitlabrc](https://github.com/lpsm-dev/gitlabrc) | cloning an entire GitLab group by hand doesn't scale - one command does it | ![stars](https://img.shields.io/github/stars/lpsm-dev/gitlabrc?style=flat-square&labelColor=black&color=white&label=%E2%98%85) |
 
 [all repositories →](https://github.com/lpsm-dev?tab=repositories)
+<!-- gen:pinned:end -->
 
 ## `$ contributions`
 
@@ -102,6 +106,7 @@ My registry-pruning tool [drprune](https://github.com/lpsm-dev/drprune) needed t
 
 ## `$ certifications`
 
+<!-- gen:certifications:start -->
 <samp>26 verified badges on [credly](https://www.credly.com/users/lucca-matos)</samp>
 
 <p align="center">
@@ -129,6 +134,7 @@ My registry-pruning tool [drprune](https://github.com/lpsm-dev/drprune) needed t
   <a href="https://www.credly.com/badges/1efaf3e3-2681-435e-ab88-49d1f00e8ff7/public_url"><img alt="HashiCorp Certified: Terraform Associate (002)" src="https://images.credly.com/size/150x150/images/cd038261-9d1c-4792-bc62-3a3b5bda175c/blob" width="110"></a>
   <a href="https://www.credly.com/badges/7f10e522-85f3-4b0b-8a24-9e021965355a/public_url"><img alt="GitHub Foundations" src="https://images.credly.com/size/150x150/images/024d0122-724d-4c5a-bd83-cfe3c4b7a073/image.png" width="110"></a>
 </p>
+<!-- gen:certifications:end -->
 
 <details>
 <summary>training badges</summary>
@@ -152,7 +158,9 @@ My registry-pruning tool [drprune](https://github.com/lpsm-dev/drprune) needed t
 
 ## `$ interests`
 
+<!-- gen:interests:start -->
 <samp>Adventure sports · Anime · Camping · Music · Craft beer · Travel</samp>
+<!-- gen:interests:end -->
 
 ## `$ stats`
 

--- a/data/profile.cli.json
+++ b/data/profile.cli.json
@@ -1,0 +1,136 @@
+{
+  "en": {
+    "whoami": [
+      "Lucca Matos - cloud & platform engineer who lives in the terminal.",
+      "I build automation for cloud operations, DevSecOps and AI agents.",
+      "Big on infrastructure as code, CI/CD and making boring ops disappear."
+    ],
+    "now": [
+      "Building AI agent platforms for cloud operations (Bedrock, MCP).",
+      "Embedding security into pipelines: SAST, SCA, secrets and IaC scanning.",
+      "Exploring platform engineering and internal developer platforms."
+    ],
+    "languages": [
+      "Go",
+      "Python",
+      "TypeScript",
+      "Bash",
+      "JavaScript"
+    ],
+    "stack": [
+      "Languages:     ShellScript, Powershell, Python, C, C++, Ruby, Go, JS, Rust, TypeScript",
+      "Cloud:         AWS, GCP",
+      "Containers:    Kubernetes, Docker, Helm, Argo",
+      "IaC:           Terraform, Ansible",
+      "CI/CD:         GitHub Actions, GitLab CI, Azure DevOps",
+      "Observability: Prometheus, Grafana, Datadog",
+      "AI:            Claude, MCP, Amazon Bedrock",
+      "Frontend:      React",
+      "OS:            Linux, Windows",
+      "Tools:         Git"
+    ],
+    "projects": [
+      "docker-crypto-miner - github.com/lpsm-dev/docker-crypto-miner",
+      "loli                - github.com/lpsm-dev/loli",
+      "azure-pipelines     - github.com/lpsm-dev/azure-pipelines",
+      "gitlabrc            - github.com/lpsm-dev/gitlabrc",
+      "more                - github.com/lpsm-dev?tab=repositories"
+    ],
+    "certifications": [
+      "AWS Certified DevOps Engineer - Professional",
+      "AWS Certified Security - Specialty",
+      "AWS Certified Solutions Architect - Associate",
+      "AWS Certified SysOps Administrator - Associate",
+      "AWS Certified AI Practitioner",
+      "AWS Certified Cloud Practitioner",
+      "CKAD: Certified Kubernetes Application Developer",
+      "KCSA: Kubernetes and Cloud Native Security Associate",
+      "KCNA: Kubernetes and Cloud Native Associate",
+      "PCA: Prometheus Certified Associate",
+      "CAPA: Certified Argo Project Associate",
+      "HashiCorp Certified: Terraform Associate (004)",
+      "HashiCorp Certified: Terraform Associate (002)",
+      "GitHub Foundations",
+      "26 verified badges - credly.com/users/lucca-matos"
+    ],
+    "interests": [
+      "Adventure sports",
+      "Anime",
+      "Camping",
+      "Music",
+      "Craft beer",
+      "Travel"
+    ],
+    "contact": [
+      "Blog:   https://blog.lpsm.cloud",
+      "GitHub: https://github.com/lpsm-dev"
+    ]
+  },
+  "pt": {
+    "whoami": [
+      "Lucca Matos - engenheiro de cloud & plataforma que vive no terminal.",
+      "Construo automação para operações cloud, DevSecOps e agentes de IA.",
+      "Fã de infraestrutura como código, CI/CD e de fazer op chato sumir."
+    ],
+    "agora": [
+      "Construindo plataformas de agentes de IA para operações cloud (Bedrock, MCP).",
+      "Colocando segurança nas pipelines: SAST, SCA, secrets e scan de IaC.",
+      "Explorando platform engineering e internal developer platforms."
+    ],
+    "linguagens": [
+      "Go",
+      "Python",
+      "TypeScript",
+      "Bash",
+      "JavaScript"
+    ],
+    "stack": [
+      "Languages:     ShellScript, Powershell, Python, C, C++, Ruby, Go, JS, Rust, TypeScript",
+      "Cloud:         AWS, GCP",
+      "Containers:    Kubernetes, Docker, Helm, Argo",
+      "IaC:           Terraform, Ansible",
+      "CI/CD:         GitHub Actions, GitLab CI, Azure DevOps",
+      "Observability: Prometheus, Grafana, Datadog",
+      "AI:            Claude, MCP, Amazon Bedrock",
+      "Frontend:      React",
+      "OS:            Linux, Windows",
+      "Tools:         Git"
+    ],
+    "projetos": [
+      "docker-crypto-miner - github.com/lpsm-dev/docker-crypto-miner",
+      "loli                - github.com/lpsm-dev/loli",
+      "azure-pipelines     - github.com/lpsm-dev/azure-pipelines",
+      "gitlabrc            - github.com/lpsm-dev/gitlabrc",
+      "mais                - github.com/lpsm-dev?tab=repositories"
+    ],
+    "certificações": [
+      "AWS Certified DevOps Engineer - Professional",
+      "AWS Certified Security - Specialty",
+      "AWS Certified Solutions Architect - Associate",
+      "AWS Certified SysOps Administrator - Associate",
+      "AWS Certified AI Practitioner",
+      "AWS Certified Cloud Practitioner",
+      "CKAD: Certified Kubernetes Application Developer",
+      "KCSA: Kubernetes and Cloud Native Security Associate",
+      "KCNA: Kubernetes and Cloud Native Associate",
+      "PCA: Prometheus Certified Associate",
+      "CAPA: Certified Argo Project Associate",
+      "HashiCorp Certified: Terraform Associate (004)",
+      "HashiCorp Certified: Terraform Associate (002)",
+      "GitHub Foundations",
+      "26 badges verificados - credly.com/users/lucca-matos"
+    ],
+    "interesses": [
+      "Esportes de aventura",
+      "Anime",
+      "Acampar",
+      "Música",
+      "Cerveja artesanal",
+      "Viagens"
+    ],
+    "contato": [
+      "Blog:   https://blog.lpsm.cloud",
+      "GitHub: https://github.com/lpsm-dev"
+    ]
+  }
+}

--- a/data/profile.json
+++ b/data/profile.json
@@ -17,37 +17,6 @@
       "Bash",
       "JavaScript"
     ],
-    "stack": [
-      "Cloud:      AWS",
-      "Containers: Kubernetes, Docker, Helm, ArgoCD",
-      "IaC:        Terraform, AWS CDK, Crossplane",
-      "CI/CD:      GitHub Actions, GitLab CI, Azure DevOps",
-      "DevSecOps:  Trivy, Checkov, SonarQube, Gitleaks",
-      "Platform:   Backstage, MCP, AI agents"
-    ],
-    "projects": [
-      "docker-crypto-miner - github.com/lpsm-dev/docker-crypto-miner",
-      "loli                - github.com/lpsm-dev/loli",
-      "azure-pipelines     - github.com/lpsm-dev/azure-pipelines",
-      "gitlabrc            - github.com/lpsm-dev/gitlabrc",
-      "more                - github.com/lpsm-dev?tab=repositories"
-    ],
-    "certifications": [
-      "AWS DevOps Engineer - Professional",
-      "AWS Security - Specialty",
-      "AWS Solutions Architect - Associate",
-      "AWS SysOps Administrator - Associate",
-      "AWS AI Practitioner",
-      "AWS Cloud Practitioner",
-      "CKAD - Kubernetes Application Developer",
-      "KCSA - Kubernetes Cloud Native Security Associate",
-      "KCNA - Kubernetes Cloud Native Associate",
-      "PCA - Prometheus Certified Associate",
-      "CAPA - Argo Project Associate",
-      "HashiCorp Terraform Associate (002, 004)",
-      "GitHub Foundations",
-      "26 verified badges - credly.com/users/lucca-matos"
-    ],
     "interests": [
       "Adventure sports",
       "Anime",
@@ -79,37 +48,6 @@
       "Bash",
       "JavaScript"
     ],
-    "stack": [
-      "Cloud:      AWS",
-      "Containers: Kubernetes, Docker, Helm, ArgoCD",
-      "IaC:        Terraform, AWS CDK, Crossplane",
-      "CI/CD:      GitHub Actions, GitLab CI, Azure DevOps",
-      "DevSecOps:  Trivy, Checkov, SonarQube, Gitleaks",
-      "Plataforma: Backstage, MCP, agentes de IA"
-    ],
-    "projetos": [
-      "docker-crypto-miner - github.com/lpsm-dev/docker-crypto-miner",
-      "loli                - github.com/lpsm-dev/loli",
-      "azure-pipelines     - github.com/lpsm-dev/azure-pipelines",
-      "gitlabrc            - github.com/lpsm-dev/gitlabrc",
-      "mais                - github.com/lpsm-dev?tab=repositories"
-    ],
-    "certificações": [
-      "AWS DevOps Engineer - Professional",
-      "AWS Security - Specialty",
-      "AWS Solutions Architect - Associate",
-      "AWS SysOps Administrator - Associate",
-      "AWS AI Practitioner",
-      "AWS Cloud Practitioner",
-      "CKAD - Kubernetes Application Developer",
-      "KCSA - Kubernetes Cloud Native Security Associate",
-      "KCNA - Kubernetes Cloud Native Associate",
-      "PCA - Prometheus Certified Associate",
-      "CAPA - Argo Project Associate",
-      "HashiCorp Terraform Associate (002, 004)",
-      "GitHub Foundations",
-      "26 badges verificados - credly.com/users/lucca-matos"
-    ],
     "interesses": [
       "Esportes de aventura",
       "Anime",
@@ -121,6 +59,271 @@
     "contato": [
       "Blog:   https://blog.lpsm.cloud",
       "GitHub: https://github.com/lpsm-dev"
+    ]
+  },
+  "stack": [
+    {
+      "name": "Linux",
+      "group": "os",
+      "badge": "https://img.shields.io/badge/-Linux-black?style=for-the-badge&logo=linux&logoColor=white"
+    },
+    {
+      "name": "Windows",
+      "group": "os",
+      "badge": "https://img.shields.io/badge/-Windows-black?&style=for-the-badge&logo=windows&logoColor=white"
+    },
+    {
+      "name": "Git",
+      "group": "tools",
+      "badge": "https://img.shields.io/badge/-Git-black?style=for-the-badge&logo=git&logoColor=white"
+    },
+    {
+      "name": "ShellScript",
+      "group": "languages",
+      "badge": "https://img.shields.io/badge/-ShellScript-black?style=for-the-badge&logo=gnu%20bash&logoColor=white"
+    },
+    {
+      "name": "Powershell",
+      "group": "languages",
+      "badge": "https://img.shields.io/badge/-PowerShell-black?&style=for-the-badge&logo=powershell&logoColor=white"
+    },
+    {
+      "name": "Python",
+      "group": "languages",
+      "badge": "https://img.shields.io/badge/Python-black?style=for-the-badge&logo=python&logoColor=white"
+    },
+    {
+      "name": "C",
+      "group": "languages",
+      "badge": "https://img.shields.io/badge/C-black?style=for-the-badge&logo=c&logoColor=white"
+    },
+    {
+      "name": "C++",
+      "group": "languages",
+      "badge": "https://img.shields.io/badge/C%2B%2B-black?style=for-the-badge&logo=c%2B%2B&logoColor=white"
+    },
+    {
+      "name": "Ruby",
+      "group": "languages",
+      "badge": "https://img.shields.io/badge/Ruby-black?style=for-the-badge&logo=ruby&logoColor=white"
+    },
+    {
+      "name": "Go",
+      "group": "languages",
+      "badge": "https://img.shields.io/badge/Go-black?style=for-the-badge&logo=go&logoColor=white"
+    },
+    {
+      "name": "JS",
+      "group": "languages",
+      "badge": "https://img.shields.io/badge/JS-black?style=for-the-badge&logo=javascript&logoColor=white"
+    },
+    {
+      "name": "Rust",
+      "group": "languages",
+      "badge": "https://img.shields.io/badge/Rust-black?style=for-the-badge&logo=rust&logoColor=white"
+    },
+    {
+      "name": "Kubernetes",
+      "group": "containers",
+      "badge": "https://img.shields.io/badge/Kubernetes-black?style=for-the-badge&logo=kubernetes&logoColor=white"
+    },
+    {
+      "name": "Docker",
+      "group": "containers",
+      "badge": "https://img.shields.io/badge/Docker-black?style=for-the-badge&logo=docker&logoColor=white"
+    },
+    {
+      "name": "Helm",
+      "group": "containers",
+      "badge": "https://img.shields.io/badge/Helm-black?style=for-the-badge&logo=helm&logoColor=white"
+    },
+    {
+      "name": "AWS",
+      "group": "cloud",
+      "badge": "https://img.shields.io/badge/AWS-black?style=for-the-badge"
+    },
+    {
+      "name": "GCP",
+      "group": "cloud",
+      "badge": "https://img.shields.io/badge/GCP-black?style=for-the-badge&logo=googlecloud&logoColor=white"
+    },
+    {
+      "name": "Terraform",
+      "group": "iac",
+      "badge": "https://img.shields.io/badge/Terraform-black?style=for-the-badge&logo=terraform&logoColor=white"
+    },
+    {
+      "name": "Ansible",
+      "group": "iac",
+      "badge": "https://img.shields.io/badge/Ansible-black?style=for-the-badge&logo=ansible&logoColor=white"
+    },
+    {
+      "name": "GitHub Actions",
+      "group": "cicd",
+      "badge": "https://img.shields.io/badge/GitHub%20Actions-black?style=for-the-badge&logo=githubactions&logoColor=white"
+    },
+    {
+      "name": "GitLab CI",
+      "group": "cicd",
+      "badge": "https://img.shields.io/badge/GitLab%20CI-black?style=for-the-badge&logo=gitlab&logoColor=white"
+    },
+    {
+      "name": "Azure DevOps",
+      "group": "cicd",
+      "badge": "https://img.shields.io/badge/Azure%20DevOps-black?style=for-the-badge"
+    },
+    {
+      "name": "Argo",
+      "group": "containers",
+      "badge": "https://img.shields.io/badge/Argo-black?style=for-the-badge&logo=argo&logoColor=white"
+    },
+    {
+      "name": "Prometheus",
+      "group": "observability",
+      "badge": "https://img.shields.io/badge/Prometheus-black?style=for-the-badge&logo=prometheus&logoColor=white"
+    },
+    {
+      "name": "Grafana",
+      "group": "observability",
+      "badge": "https://img.shields.io/badge/Grafana-black?style=for-the-badge&logo=grafana&logoColor=white"
+    },
+    {
+      "name": "Datadog",
+      "group": "observability",
+      "badge": "https://img.shields.io/badge/Datadog-black?style=for-the-badge&logo=datadog&logoColor=white"
+    },
+    {
+      "name": "TypeScript",
+      "group": "languages",
+      "badge": "https://img.shields.io/badge/TypeScript-black?style=for-the-badge&logo=typescript&logoColor=white"
+    },
+    {
+      "name": "React",
+      "group": "frontend",
+      "badge": "https://img.shields.io/badge/React-black?style=for-the-badge&logo=react&logoColor=white"
+    },
+    {
+      "name": "Claude",
+      "group": "ai",
+      "badge": "https://img.shields.io/badge/Claude-black?style=for-the-badge&logo=anthropic&logoColor=white"
+    },
+    {
+      "name": "MCP",
+      "group": "ai",
+      "badge": "https://img.shields.io/badge/MCP-black?style=for-the-badge&logo=modelcontextprotocol&logoColor=white"
+    },
+    {
+      "name": "Amazon Bedrock",
+      "group": "ai",
+      "badge": "https://img.shields.io/badge/Amazon%20Bedrock-black?style=for-the-badge"
+    }
+  ],
+  "projects": [
+    {
+      "name": "docker-crypto-miner",
+      "url": "https://github.com/lpsm-dev/docker-crypto-miner",
+      "description": "mining setups are a dependency mess - this image makes it one `docker run`"
+    },
+    {
+      "name": "loli",
+      "url": "https://github.com/lpsm-dev/loli",
+      "description": "you have the screenshot but not the anime name - this CLI finds it"
+    },
+    {
+      "name": "azure-pipelines",
+      "url": "https://github.com/lpsm-dev/azure-pipelines",
+      "description": "reusable build, scan and deploy steps so every project doesn't reinvent them"
+    },
+    {
+      "name": "gitlabrc",
+      "url": "https://github.com/lpsm-dev/gitlabrc",
+      "description": "cloning an entire GitLab group by hand doesn't scale - one command does it"
+    }
+  ],
+  "certifications": {
+    "credly": "https://www.credly.com/users/lucca-matos",
+    "count": 26,
+    "note": {
+      "en": "verified badges",
+      "pt": "badges verificados"
+    },
+    "rows": [
+      5,
+      4,
+      3,
+      2
+    ],
+    "items": [
+      {
+        "name": "AWS Certified DevOps Engineer - Professional",
+        "badge": "https://www.credly.com/badges/1f622842-f7c4-4fbb-81d0-ee345eade037/public_url",
+        "image": "https://images.credly.com/size/150x150/images/bd31ef42-d460-493e-8503-39592aaf0458/image.png"
+      },
+      {
+        "name": "AWS Certified Security - Specialty",
+        "badge": "https://www.credly.com/badges/7d9c27b9-f300-4faf-b5a5-57508e7e362f/public_url",
+        "image": "https://images.credly.com/size/150x150/images/53acdae5-d69f-4dda-b650-d02ed7a50dd7/image.png"
+      },
+      {
+        "name": "AWS Certified Solutions Architect - Associate",
+        "badge": "https://www.credly.com/badges/eba53ed6-5eb4-4f15-8b8d-fb8e30288a5e/public_url",
+        "image": "https://images.credly.com/size/150x150/images/0e284c3f-5164-4b21-8660-0d84737941bc/image.png"
+      },
+      {
+        "name": "AWS Certified SysOps Administrator - Associate",
+        "badge": "https://www.credly.com/badges/04098c67-f89d-4372-b248-3fe85a3fcd86/public_url",
+        "image": "https://images.credly.com/size/150x150/images/f0d3fbb9-bfa7-4017-9989-7bde8eaf42b1/image.png"
+      },
+      {
+        "name": "AWS Certified AI Practitioner",
+        "badge": "https://www.credly.com/badges/ddb545d2-3044-4eb7-b48a-f3f4b07df8ee/public_url",
+        "image": "https://images.credly.com/size/150x150/images/4d4693bb-530e-4bca-9327-de07f3aa2348/image.png"
+      },
+      {
+        "name": "AWS Certified Cloud Practitioner",
+        "badge": "https://www.credly.com/badges/2027791d-c718-4a44-bdfb-c199dc4dfa41/public_url",
+        "image": "https://images.credly.com/size/150x150/images/00634f82-b07f-4bbd-a6bb-53de397fc3a6/image.png"
+      },
+      {
+        "name": "CKAD: Certified Kubernetes Application Developer",
+        "badge": "https://www.credly.com/badges/26d70dd2-b56b-4341-8131-8834b37bc666/public_url",
+        "image": "https://images.credly.com/size/150x150/images/cc8adc83-1dc6-4d57-8e20-22171247e052/blob"
+      },
+      {
+        "name": "KCSA: Kubernetes and Cloud Native Security Associate",
+        "badge": "https://www.credly.com/badges/fb86997b-b952-45c6-b209-cade8a42912f/public_url",
+        "image": "https://images.credly.com/size/150x150/images/67dd8a95-8876-4051-9cb9-3d97c204f85a/image.png"
+      },
+      {
+        "name": "KCNA: Kubernetes and Cloud Native Associate",
+        "badge": "https://www.credly.com/badges/8911adbe-a95b-492a-8ec7-22658435aff1/public_url",
+        "image": "https://images.credly.com/size/150x150/images/f28f1d88-428a-47f6-95b5-7da1dd6c1000/KCNA_badge.png"
+      },
+      {
+        "name": "PCA: Prometheus Certified Associate",
+        "badge": "https://www.credly.com/badges/f8eb8971-ae9c-407f-9d78-19913e80c672/public_url",
+        "image": "https://images.credly.com/size/150x150/images/c34436dc-1cfd-4125-a862-35f9c86ca17f/image.png"
+      },
+      {
+        "name": "CAPA: Certified Argo Project Associate",
+        "badge": "https://www.credly.com/badges/4a69cc85-24c0-49d5-a580-f31c23aaec1b/public_url",
+        "image": "https://images.credly.com/size/150x150/images/12624f9e-6b4a-43f0-b7a2-afb2c6cf8059/image.png"
+      },
+      {
+        "name": "HashiCorp Certified: Terraform Associate (004)",
+        "badge": "https://www.credly.com/badges/a6d780cc-5462-49df-9641-cd9f3be86a6b/public_url",
+        "image": "https://images.credly.com/size/150x150/images/0e717fa5-93a1-4203-964c-051b4734b7eb/blob"
+      },
+      {
+        "name": "HashiCorp Certified: Terraform Associate (002)",
+        "badge": "https://www.credly.com/badges/1efaf3e3-2681-435e-ab88-49d1f00e8ff7/public_url",
+        "image": "https://images.credly.com/size/150x150/images/cd038261-9d1c-4792-bc62-3a3b5bda175c/blob"
+      },
+      {
+        "name": "GitHub Foundations",
+        "badge": "https://www.credly.com/badges/7f10e522-85f3-4b0b-8a24-9e021965355a/public_url",
+        "image": "https://images.credly.com/size/150x150/images/024d0122-724d-4c5a-bd83-cfe3c4b7a073/image.png"
+      }
     ]
   }
 }

--- a/scripts/render.mjs
+++ b/scripts/render.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// Single source of truth -> generated surfaces.
+// Reads data/profile.json (structured) and regenerates:
+//   1. the marked sections of README.md (stack, pinned, certifications, interests)
+//   2. data/profile.cli.json (flattened strings consumed by the npx lpsm-dev CLI)
+// Run: `node scripts/render.mjs`. CI runs it with --check to fail on drift.
+import {readFileSync, writeFileSync} from 'node:fs';
+
+const root = new URL('..', import.meta.url).pathname;
+const data = JSON.parse(readFileSync(root + 'data/profile.json', 'utf8'));
+const check = process.argv.includes('--check');
+
+// ---------- README section renderers ----------
+const renderInterests = () => `<samp>${data.en.interests.join(' · ')}</samp>`;
+
+const renderStack = () =>
+  ['<p>', ...data.stack.map((t) => `  <img alt="${t.name}" src="${t.badge}">`), '</p>'].join('\n');
+
+const starBadge = (name) =>
+  `![stars](https://img.shields.io/github/stars/lpsm-dev/${name}?style=flat-square&labelColor=black&color=white&label=%E2%98%85)`;
+
+const renderPinned = () =>
+  [
+    '| repo | description | stars |',
+    '| --- | --- | --- |',
+    ...data.projects.map((p) => `| [${p.name}](${p.url}) | ${p.description} | ${starBadge(p.name)} |`),
+    '',
+    '[all repositories →](https://github.com/lpsm-dev?tab=repositories)',
+  ].join('\n');
+
+function renderCerts() {
+  const c = data.certifications;
+  const lines = [`<samp>${c.count} verified badges on [credly](${c.credly})</samp>`, ''];
+  let i = 0;
+  for (const size of c.rows) {
+    const row = c.items.slice(i, i + size);
+    i += size;
+    const imgs = row.map(
+      (b) => `  <a href="${b.badge}"><img alt="${b.name}" src="${b.image}" width="110"></a>`,
+    );
+    lines.push('<p align="center">', ...imgs, '</p>', '');
+  }
+  lines.pop();
+  return lines.join('\n');
+}
+
+// ---------- CLI flattening ----------
+const GROUPS = [
+  ['languages', 'Languages'],
+  ['cloud', 'Cloud'],
+  ['containers', 'Containers'],
+  ['iac', 'IaC'],
+  ['cicd', 'CI/CD'],
+  ['observability', 'Observability'],
+  ['ai', 'AI'],
+  ['frontend', 'Frontend'],
+  ['os', 'OS'],
+  ['tools', 'Tools'],
+];
+const stackPad = Math.max(...GROUPS.map(([, l]) => l.length)) + 2;
+const flattenStack = () =>
+  GROUPS.filter(([g]) => data.stack.some((t) => t.group === g)).map(([g, label]) => {
+    const names = data.stack.filter((t) => t.group === g).map((t) => t.name).join(', ');
+    return `${(label + ':').padEnd(stackPad)}${names}`;
+  });
+
+const projPad = Math.max(...data.projects.map((p) => p.name.length), 'more'.length);
+const flattenProjects = (moreLabel) => [
+  ...data.projects.map((p) => `${p.name.padEnd(projPad)} - ${p.url.replace(/^https:\/\//, '')}`),
+  `${moreLabel.padEnd(projPad)} - github.com/lpsm-dev?tab=repositories`,
+];
+
+const flattenCerts = (lang) => [
+  ...data.certifications.items.map((i) => i.name),
+  `${data.certifications.count} ${data.certifications.note[lang]} - credly.com/users/lucca-matos`,
+];
+
+function buildCli() {
+  const stack = flattenStack();
+  const en = {
+    whoami: data.en.whoami,
+    now: data.en.now,
+    languages: data.en.languages,
+    stack,
+    projects: flattenProjects('more'),
+    certifications: flattenCerts('en'),
+    interests: data.en.interests,
+    contact: data.en.contact,
+  };
+  const pt = {
+    whoami: data.pt.whoami,
+    agora: data.pt.agora,
+    linguagens: data.pt.linguagens,
+    stack,
+    projetos: flattenProjects('mais'),
+    'certificações': flattenCerts('pt'),
+    interesses: data.pt.interesses,
+    contato: data.pt.contato,
+  };
+  return {en, pt};
+}
+
+// ---------- apply ----------
+function replaceSection(md, key, content) {
+  const re = new RegExp(`(<!-- gen:${key}:start -->\\n)[\\s\\S]*?(\\n<!-- gen:${key}:end -->)`);
+  if (!re.test(md)) throw new Error(`marker not found for section: ${key}`);
+  return md.replace(re, `$1${content}$2`);
+}
+
+let readme = readFileSync(root + 'README.md', 'utf8');
+readme = replaceSection(readme, 'stack', renderStack());
+readme = replaceSection(readme, 'pinned', renderPinned());
+readme = replaceSection(readme, 'certifications', renderCerts());
+readme = replaceSection(readme, 'interests', renderInterests());
+const cli = JSON.stringify(buildCli(), null, 2) + '\n';
+
+if (check) {
+  const curReadme = readFileSync(root + 'README.md', 'utf8');
+  const curCli = readFileSync(root + 'data/profile.cli.json', 'utf8');
+  if (curReadme !== readme || curCli !== cli) {
+    console.error('drift: README.md or data/profile.cli.json is out of sync with data/profile.json');
+    console.error('run `node scripts/render.mjs` and commit the result.');
+    process.exit(1);
+  }
+  console.log('render check passed: surfaces in sync with the source of truth');
+} else {
+  writeFileSync(root + 'README.md', readme);
+  writeFileSync(root + 'data/profile.cli.json', cli);
+  console.log('rendered README.md sections + data/profile.cli.json from data/profile.json');
+}


### PR DESCRIPTION
Fase 2: o `data/profile.json` vira **estruturado** e passa a gerar as seções do README e o dado do CLI. Zero duplicação, zero drift.

## O que muda
- `data/profile.json` reestruturado: `stack` (31 techs, com grupo + badge), `projects` (nome, url, **descrição**), `certifications` (14 badges com imagem + link do Credly), mais a prosa por idioma.
- `scripts/render.mjs` gera:
  1. As 4 seções marcadas do README (`stack`, `pinned`, `certifications`, `interests`) - **byte a byte idênticas** ao que estava escrito à mão.
  2. `data/profile.cli.json` - versão achatada (strings) que o `npx lpsm-dev` consome.
- Marcadores `<!-- gen:X:start/end -->` no README delimitam o que é gerado. O resto (about, whoami, contributions, stats, training badges) fica à mão = as exceções.
- CI: `node scripts/render.mjs --check` falha se README ou cli.json divergirem do `data/profile.json`.

## Exatidão
O diff do README é só a adição dos 8 marcadores - **zero mudança de conteúdo visível**. Prova que o gerador reproduz o profile atual fielmente.

## Fluxo daqui pra frente
Muda algo do perfil (novo pin, cert, interesse)? Edita **só** o `data/profile.json`, roda `node scripts/render.mjs`, commita. README e CLI acompanham juntos.

Próximo PR (personal-resume): apontar o sync do CLI pra `data/profile.cli.json`.